### PR TITLE
Implement Batch Query Method in Client

### DIFF
--- a/examples/cookbook/alt_client_demo.py
+++ b/examples/cookbook/alt_client_demo.py
@@ -1,17 +1,17 @@
 from helix.client import Client, Query
 from helix.types import Payload
 from typing import List
-from helix.instance import Instance
+from datetime import datetime, timezone
 
 db = Client(local=True, port=6969)
 
 class create_user(Query):
-    def __init__(self, name:str, age:int, email:str, now:int):
+    def __init__(self, name:str, age:int, email:str, now:datetime):
         super().__init__()
         self.name = name
         self.age = age
         self.email = email
-        self.now = now
+        self.now = now.isoformat()
 
     def query(self) -> List[Payload]:
         return [{"name": self.name, "age": self.age, "email": self.email, "now": self.now}]
@@ -30,11 +30,11 @@ class get_users(Query):
         return response
 
 class create_follow(Query):
-    def __init__(self, follower_id: str, followed_id: str, now: int):
+    def __init__(self, follower_id: str, followed_id: str, now: datetime):
         super().__init__()
         self.follower_id = follower_id
         self.followed_id = followed_id
-        self.now = now
+        self.now = now.isoformat()
 
     def query(self):
         return [{"follower_id": self.follower_id, "followed_id": self.followed_id, "now": self.now}]
@@ -44,11 +44,11 @@ class create_follow(Query):
         return response
 
 class create_post(Query):
-    def __init__(self, user_id: str, content: str, now: int):
+    def __init__(self, user_id: str, content: str, now: datetime):
         super().__init__()
         self.user_id = user_id
         self.content = content
-        self.now = now
+        self.now = now.isoformat()
 
     def query(self):
         return [{"user_id": self.user_id, "content": self.content, "now": self.now}]
@@ -102,8 +102,8 @@ class get_followed_users_posts(Query):
         return response
 
 print("\n" + "-"*20 + "CREATE USERS" + "-"*20)
-user1 = db.query(create_user("John", 30, "john@example.com", 1722222222))
-user2 = db.query(create_user("Jane", 25, "jane@example.com", 1722222222))
+user1 = db.query(create_user("John", 30, "john@example.com", datetime.now(timezone.utc)))
+user2 = db.query(create_user("Jane", 25, "jane@example.com", datetime.now(timezone.utc)))
 print(user1, "\n", user2)
 print("\n")
 
@@ -117,14 +117,14 @@ print("\n")
 
 print("-"*20 + "CREATE FOLLOW" + "-"*20)
 print("Jane follows John")
-print(db.query(create_follow(user1_id, user2_id, 1892222222)))
+print(db.query(create_follow(user1_id, user2_id, datetime.now(timezone.utc))))
 print("\n")
 
 print("-"*20 + "CREATE POST" + "-"*20)
 content1 = "Sample Post Content Hello World 1"
 content2 = "Sample Post Content Hello World 2"
-print(db.query(create_post(user1_id, content1, 1983333333))[0]['post'])
-print(db.query(create_post(user2_id, content2, 1983333333))[0]['post'])
+print(db.query(create_post(user1_id, content1, datetime.now(timezone.utc)))[0]['post'])
+print(db.query(create_post(user2_id, content2, datetime.now(timezone.utc)))[0]['post'])
 print("\n")
 
 print("-"*20 + "GET POSTS" + "-"*20)

--- a/examples/cookbook/client_demo.py
+++ b/examples/cookbook/client_demo.py
@@ -1,14 +1,12 @@
 from helix.client import Client
-from helix.types import Payload
-from typing import List
-from helix.instance import Instance
+from datetime import datetime, timezone
 
 client = Client(local=True, port=6969)
 
 print("\n" + "-"*20 + "CREATE USERS" + "-"*20)
 users = client.query("create_user", [
-    {"name": "John", "age": 30, "email": "john@example.com", "now": 1722222222},
-    {"name": "Jane", "age": 25, "email": "jane@example.com", "now": 1722222222}
+    {"name": "John", "age": 30, "email": "john@example.com", "now": datetime.now(timezone.utc).isoformat()},
+    {"name": "Jane", "age": 25, "email": "jane@example.com", "now": datetime.now(timezone.utc).isoformat()}
 ])
 print(users)
 user1 = users[0]['user']
@@ -25,7 +23,7 @@ print("\n")
 
 print("-"*20 + "CREATE FOLLOW" + "-"*20)
 print("Jane follows John")
-print(client.query("create_follow", {"follower_id": user1_id, "followed_id": user2_id, "now": 1892222222}))
+print(client.query("create_follow", {"follower_id": user1_id, "followed_id": user2_id, "now": datetime.now(timezone.utc).isoformat()}))
 print("\n")
 
 print("-"*20 + "CREATE POST" + "-"*20)
@@ -34,8 +32,8 @@ content2 = "Sample Post Content Hello World 2"
 print(
     client.query(
         "create_post", [
-            {"user_id": user1_id, "content": content1, "now": 1983333333},
-            {"user_id": user2_id, "content": content2, "now": 1983333333}
+            {"user_id": user1_id, "content": content1, "now": datetime.now(timezone.utc).isoformat()},
+            {"user_id": user2_id, "content": content2, "now": datetime.now(timezone.utc).isoformat()}
         ]
     )[0]['post']
 )

--- a/examples/cookbook/helixdb-cfg/queries.hx
+++ b/examples/cookbook/helixdb-cfg/queries.hx
@@ -1,14 +1,14 @@
-QUERY create_user(name: String, age: U32, email: String, now: I32) =>
+QUERY create_user(name: String, age: U32, email: String, now: Date) =>
     user <- AddN<User>({name: name, age: age, email: email, created_at: now, updated_at: now})
     RETURN user
 
-QUERY create_follow(follower_id: ID, followed_id: ID, now: I32) =>
+QUERY create_follow(follower_id: ID, followed_id: ID, now: Date) =>
     follower <- N<User>(follower_id)
     followed <- N<User>(followed_id)
     AddE<Follows>({since: now})::From(follower)::To(followed)
     RETURN "success"
 
-QUERY create_post(user_id: ID, content: String, now: I32) =>
+QUERY create_post(user_id: ID, content: String, now: Date) =>
     user <- N<User>(user_id)
     post <- AddN<Post>({content: content, created_at: now, updated_at: now})
     AddE<Created>({created_at: now})::From(user)::To(post)

--- a/examples/cookbook/helixdb-cfg/schema.hx
+++ b/examples/cookbook/helixdb-cfg/schema.hx
@@ -2,21 +2,21 @@ N::User {
     name: String,
     age: U32,
     email: String,
-    created_at: I32,
-    updated_at: I32
+    created_at: Date,
+    updated_at: Date
 }
 
 N::Post {
     content: String,
-    created_at: I32,
-    updated_at: I32
+    created_at: Date,
+    updated_at: Date
 }
 
 E::Follows {
     From: User,
     To: User,
     Properties: {
-        since: I32
+        since: Date
     }
 }
 
@@ -24,7 +24,7 @@ E::Created {
     From: User,
     To: Post,
     Properties: {
-        created_at: I32
+        created_at: Date
     }
 }
 

--- a/helix/client.py
+++ b/helix/client.py
@@ -10,6 +10,7 @@ import numpy as np
 from tqdm import tqdm
 from functools import singledispatchmethod
 import sys
+from concurrent.futures import ThreadPoolExecutor
 
 class Query(ABC):
     """
@@ -82,13 +83,22 @@ class Client:
         api_endpoint (str, optional): The API endpoint to use for the Helix server.
         verbose (bool, optional): Whether to print verbose output or not. Defaults to True.
     """
-    def __init__(self, local: bool, port: int=6969, api_endpoint: str="", api_key: str=None, verbose: bool=True):
+    def __init__(
+        self, 
+        local: bool, 
+        port: int=6969, 
+        api_endpoint: str="", 
+        api_key: str=None, 
+        verbose: bool=True,
+        max_workers: int=1,
+    ):
         self.h_server_port = port
         self.h_server_api_endpoint = "" if local else api_endpoint
         self.h_server_url = "http://127.0.0.1" if local else self.h_server_api_endpoint
         self.verbose = verbose
         self.local = local
         self.api_key = api_key
+        self.max_workers = max_workers
 
         if local:
             try:
@@ -127,10 +137,12 @@ class Client:
         """
         full_endpoint = self._construct_full_url(query)
         total = len(payload) if isinstance(payload, list) else 1
-        payload = payload if isinstance(payload, list) else [payload]
-        payload = [{}] if len(payload) == 0 else payload
-
-        return self._send_reqs(payload, total, full_endpoint)
+        if isinstance(payload, list) and self.max_workers > 1 and len(payload) > 1:
+            return self._send_reqs_batched(payload, total, full_endpoint)
+        else:
+            payload = payload if isinstance(payload, list) else [payload]
+            payload = [{}] if len(payload) == 0 else payload
+            return self._send_reqs(payload, total, full_endpoint, verbose=self.verbose)
 
     @query.register
     def _(self, query: Query, payload=None) -> List[Any]:
@@ -148,9 +160,12 @@ class Client:
         full_endpoint = self._construct_full_url(query.endpoint)
         total = len(query_data) if hasattr(query_data, "__len__") else None
 
-        return self._send_reqs(query_data, total, full_endpoint, query)
+        if isinstance(query_data, list) and self.max_workers > 1 and len(query_data) > 1:
+            return self._send_reqs_batched(query_data, total, full_endpoint, query)
+        else:
+            return self._send_reqs(query_data, total, full_endpoint, query, verbose=self.verbose)
 
-    def _send_reqs(self, data, total, endpoint, query: Optional[Query]=None):
+    def _send_reqs(self, data, total, endpoint, query: Optional[Query]=None, verbose: bool=True):
         """
         Send requests to the helix server.
 
@@ -159,12 +174,13 @@ class Client:
             total (int, optional): The total number of requests to send. Defaults to None.
             endpoint (str): The endpoint to send the requests to.
             query (Query, optional): The Query object to send with the requests. Defaults to None.
+            verbose (bool, optional): Whether to print verbose output or not. Defaults to True.
 
         Returns:
             List[Any]: The response from the helix server.
         """
         responses = []
-        for d in tqdm(data, total=total, desc=f"{GHELIX} Querying '{endpoint}'", file=sys.stderr, disable=not self.verbose):
+        for d in tqdm(data, total=total, desc=f"{GHELIX} Querying '{endpoint}'", file=sys.stderr, disable=not verbose):
             req_data = json.dumps(d).encode("utf-8")
             try:
                 req = urllib.request.Request(
@@ -189,3 +205,24 @@ class Client:
 
         return responses
 
+    def _send_reqs_batched(self, data, total, endpoint, query: Optional[Query]=None):
+        """
+        Send requests to the helix server in batches.
+
+        Args:
+            data (List[Any]): The data to send.
+            total (int, optional): The total number of requests to send. Defaults to None.
+            endpoint (str): The endpoint to send the requests to.
+            query (Query, optional): The Query object to send with the requests. Defaults to None.
+
+        Returns:
+            List[Any]: The response from the helix server.
+        """
+        with ThreadPoolExecutor(max_workers=min(self.max_workers, len(data))) as executor:
+            futures = [executor.submit(self._send_reqs, [d], total, endpoint, query, False) for d in data]
+
+            responses = []
+            for future in tqdm(futures, total=len(futures), desc=f"{GHELIX} Querying '{endpoint}'", file=sys.stderr, disable=not self.verbose):
+                responses.extend(future.result())
+
+            return responses

--- a/helix/client.py
+++ b/helix/client.py
@@ -82,6 +82,7 @@ class Client:
         port (int, optional): The port to use for the Helix server. Defaults to 6969.
         api_endpoint (str, optional): The API endpoint to use for the Helix server.
         verbose (bool, optional): Whether to print verbose output or not. Defaults to True.
+        max_workers (int, optional): The maximum number of workers to use for concurrent requests. Defaults to 1.
     """
     def __init__(
         self, 
@@ -219,7 +220,7 @@ class Client:
             List[Any]: The response from the helix server.
         """
         with ThreadPoolExecutor(max_workers=min(self.max_workers, len(data))) as executor:
-            futures = [executor.submit(self._send_reqs, [d], total, endpoint, query, False) for d in data]
+            futures = [executor.submit(self._send_reqs, [d], 1, endpoint, query, False) for d in data]
 
             responses = []
             for future in tqdm(futures, total=len(futures), desc=f"{GHELIX} Querying '{endpoint}'", file=sys.stderr, disable=not self.verbose):


### PR DESCRIPTION
This pull request updates the Helix Client to include batched/concurrent request support.

**Client Enhancements**
* The Helix Python client now supports concurrent/batched requests using a `ThreadPoolExecutor`. The number of workers can be configured via the new `max_workers` parameter in the `Client` constructor, and requests are automatically batched when appropriate.

**Minor Improvements**
* Progress bars and verbosity are now handled more flexibly in the client, with batch operations showing a single progress bar for all concurrent requests.

These changes improve the scalability of the Python client for batch operations.